### PR TITLE
fix: resolve migrations directory from package root, ship with npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -28,7 +28,6 @@ AGENTS.md
 .gitignore
 
 # Data
-migrations/
 node_modules/
 
 # Dev tooling

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -18,8 +18,32 @@ const xdgDataHome = process.env["XDG_DATA_HOME"] ?? join(homedir(), ".local", "s
 const APP_DATA_DIR = join(xdgDataHome, "quran.sh");
 const DEFAULT_DB_PATH = join(APP_DATA_DIR, "quran.db");
 
-/** Resolve the migrations directory relative to this file */
-const MIGRATIONS_DIR = resolve(import.meta.dir, "..", "..", "migrations");
+/**
+ * Resolve the migrations directory by walking up from this file until we find
+ * package.json (the package root), then appending "migrations/".
+ *
+ * This works for both layouts:
+ *   - Development: src/data/db.ts  → walk up to find package.json → ./migrations/
+ *   - Bundled:     dist/index.js   → walk up to find package.json → ./migrations/
+ *
+ * The previous approach (resolve(import.meta.dir, "..", "..", "migrations"))
+ * only worked from src/data/ depth and broke when running from dist/.
+ */
+function findMigrationsDir(): string {
+  let dir = import.meta.dir;
+  for (let i = 0; i < 5; i++) {
+    if (existsSync(join(dir, "package.json"))) {
+      return join(dir, "migrations");
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // filesystem root
+    dir = parent;
+  }
+  // Fallback to the old behaviour
+  return resolve(import.meta.dir, "..", "..", "migrations");
+}
+
+const MIGRATIONS_DIR = findMigrationsDir();
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

`bunx quran.sh` (and `npm install -g quran.sh`) crashes with **"no such table: user_preferences"** on first launch because the SQLite migrations never run.

## Root cause

Two issues:

1. `migrations/` is excluded from the npm package via `.npmignore` (line 31)
2. The path resolution in `db.ts` uses `resolve(import.meta.dir, '..', '..', 'migrations')` which assumes `src/data/` depth — but the published package runs from `dist/index.js` (one level deep), so the path resolves **outside** the package entirely

Since `existsSync(MIGRATIONS_DIR)` returns `false`, `runMigrations()` silently returns without creating any tables.

## Fix

- **`src/data/db.ts`**: Walk up from `import.meta.dir` looking for `package.json` to find the package root, then resolve `migrations/` from there. Works from both `src/data/db.ts` (dev, 2 levels deep) and `dist/index.js` (bundled, 1 level deep). Falls back to the old path if `package.json` isn't found within 5 levels.
- **`.npmignore`**: Remove `migrations/` from the exclusion list so the 3 SQL files (~2.5KB total) ship with the package.

## Verification

```bash
# Build
bun run build

# Confirm migrations/ now ships
npm pack --dry-run
# → migrations/001_init.sql, 002_user_preferences.sql, 003_cues_reflections.sql now listed

# Fresh DB test from bundled output
rm -f ~/.local/share/quran.sh/quran.db
bun dist/index.js read 1      # ✓ prints Al-Fatihah
bun dist/index.js streak      # ✓ shows 0/0/0 stats (no crash)
bun dist/index.js log 1:1     # ✓ logs successfully
```