### PR TITLE
ci: pilot report-only Fallow audits

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/589885290490eeeb02fcc274defc55a3c11789dc/schema.json",
+  "entry": [
+    "src/index.ts",
+    "src/dev/**/*.{ts,tsx}",
+    "src/poc/**/*.{ts,tsx,css,html}",
+    "scripts/**/*.ts",
+    "test/**/*.{ts,tsx}"
+  ],
+  "ignoreDependencies": ["bun-webgpu", "onnxruntime-node"],
+  "duplicates": {
+    "ignore": ["test/**"],
+    "ignoreImports": true,
+    "minOccurrences": 3
+  }
+}

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run report-only Fallow audit
         uses: fallow-rs/fallow@589885290490eeeb02fcc274defc55a3c11789dc # v2.86.0
         with:
@@ -25,5 +26,4 @@ jobs:
           max-annotations: 20
           branded-token: false
           comment: false
-          summary-scope: diff
-          diff-filter: added
+          diff-filter: file

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -1,0 +1,29 @@
+name: Fallow pilot
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Report changed-code findings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Run report-only Fallow audit
+        uses: fallow-rs/fallow@589885290490eeeb02fcc274defc55a3c11789dc # v2.86.0
+        with:
+          version: 2.86.0
+          command: audit
+          gate: new-only
+          fail-on-issues: false
+          annotations: true
+          max-annotations: 20
+          branded-token: false
+          comment: false
+          summary-scope: diff
+          diff-filter: added

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # caches
 .eslintcache
 .cache
+.fallow/
 *.tsbuildinfo
 
 # IntelliJ based IDEs


### PR DESCRIPTION
## Summary
- add a tuned Fallow config for Bun tests, dev scripts, POC entry points, and dynamic dependencies
- add a PR-only changed-code audit pinned to Fallow 2.86.0 and a reviewed action SHA
- keep the pilot non-blocking, local-only, and limited to annotations/job summaries

## Evidence
- full scan: 0.50s on 150 files
- config reduced graph findings from 94 to 44, unused files from 47 to 2, and clone groups from 35 to 3
- `fallow audit --base origin/main --gate new-only`: pass
- `bun run typecheck`: pass
- build, binary build, and smoke builds: pass
- `bun test`: 197 pass, 2 pre-existing TUI failures (`layout.test.tsx` lacks `FeatureRuntimeProvider`; `immersive-dialog-flow.test.tsx` misses its timed modal state)

## Pilot limits
- does not fail PRs
- does not enable auto-fix, telemetry, branded/cloud tokens, or runtime coverage
- existing CI workflow remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request auditing for newly added code.
  * Enabled inline audit annotations and concise diff-focused reports.
  * Added configuration for project analysis and duplicate-code detection.
  * Excluded audit cache files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->